### PR TITLE
Added node versions to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
   - 'iojs'
-  - '0.12'
   - '0.10'
+  - '0.12'
+  - '4'
+  - '6'


### PR DESCRIPTION
- added '4', which should be the Argon LTS
- added '6', which should be the Boron LTS

Also, TravisCI needs to be activated for this repository.  It's only active on your personal branch.  I don't have access to turn it on.